### PR TITLE
Do not wrap `<Transition>` child in a div

### DIFF
--- a/src/factory/choreography.js
+++ b/src/factory/choreography.js
@@ -173,11 +173,12 @@ const choreography = (
           })}
           {...rest}
         >
-          {state => (
-            <div style={this.getFinalStyle(state, timeout, easing, start, end)}>
-              {children}
-            </div>
-          )}
+          {state => {
+            const child = React.Children.only(children);
+            return React.cloneElement(child, {
+              style: this.getFinalStyle(state, timeout, easing, start, end),
+            });
+          }}
         </Transition>
       );
     }

--- a/src/factory/choreography.js
+++ b/src/factory/choreography.js
@@ -106,7 +106,7 @@ const choreography = (
             styles.exiting[config.transition],
             config.getStartStyle(startVal)
           );
-          styles.exited[config.transition] = styles.entering;
+          styles.exited[config.transition] = styles.entering[config.transition];
           return styles;
         },
         {

--- a/src/factory/choreography.js
+++ b/src/factory/choreography.js
@@ -173,10 +173,17 @@ const choreography = (
           })}
           {...rest}
         >
-          {state => {
+          {(state, childProps) => {
+            const style = this.getFinalStyle(state, timeout, easing, start, end);
+
+            if (typeof children === 'function') {
+              childProps.style = style;
+              return children(state, childProps)
+            }
+
             const child = React.Children.only(children);
             return React.cloneElement(child, {
-              style: this.getFinalStyle(state, timeout, easing, start, end),
+              style,
             });
           }}
         </Transition>

--- a/stories/components/KatPersona.js
+++ b/stories/components/KatPersona.js
@@ -16,11 +16,13 @@ const examplePersona = {
   showSecondaryText: true,
 };
 
-export default () => (
-  <Persona
-    {...examplePersona}
-    size={PersonaSize.large}
-    presence={PersonaPresence.blocked}
-    className="inlineFlex"
-  />
+export default ({ style }) => (
+  <div style={style}>
+    <Persona
+      {...examplePersona}
+      size={PersonaSize.large}
+      presence={PersonaPresence.blocked}
+      className="inlineFlex"
+    />
+  </div>
 );

--- a/stories/index.js
+++ b/stories/index.js
@@ -34,7 +34,9 @@ storiesOf('Standard Transitions', module)
   ))
   .add('Slide (Top)', () => (
     <SlideTransition direction="top">
-      <KatPersona />
+      {(state, { style }) => (
+        <KatPersona style={style} />
+      )}
     </SlideTransition>
   ))
   .add('Slide (Left)', () => (


### PR DESCRIPTION
This allows consumers to decide for themselves what the dom structure of the children of the output <Transition> will be. Note the change to `KatPersona.js` this means that consumers must pass the `style` prop into their component (this was previously being done by the wrapper)