### PR TITLE
feat(factory): Simplify API for v2 [WIP]

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-transition-factory",
-  "version": "1.1.0",
+  "version": "2.0.0-alpha.1",
   "description": "Simple transition / animation component creation for React",
   "license": "MIT",
   "repository": {

--- a/src/factory/index.js
+++ b/src/factory/index.js
@@ -34,16 +34,15 @@ const getStyleString = (
     ? `${currentStyle} ${style}`
     : style;
 
-const transitionFactory = (
-  transitionConfigs: Array<TransitionConfig>,
-  staticStyles?: Object,
-  defaultProps?: TransitionProps
-) => {
+const transitionFactory = () => {
+  const transitions: Array<TransitionConfig> = [...arguments];
+
   return class extends React.Component<TransitionProps> {
+    static transitions = transitions;
+
     static defaultProps = {
       timeout: 300,
       easing: 'ease-in-out',
-      ...defaultProps,
     };
 
     constructor(props: TransitionProps) {
@@ -62,7 +61,7 @@ const transitionFactory = (
     });
 
     getTransitionProperty = (timeout: number, easing: string): string => {
-      return transitionConfigs
+      return transitions
         .map((config, index) => {
           const timeoutVal = getPrimitiveValue(timeout, index);
           const easingVal = getPrimitiveValue(easing, index);
@@ -78,8 +77,7 @@ const transitionFactory = (
     ): Object => {
       return {
         transition: this.getTransitionProperty(timeout, easing),
-        ...(this.props.staticStyles || staticStyles),
-        ...transitionConfigs.reduce((style, config, index) => {
+        ...transitions.reduce((style, config, index) => {
           const startVal = getPrimitiveValue(start, index);
           const transitionName = camelCase(config.transition);
 
@@ -99,7 +97,7 @@ const transitionFactory = (
       start: ArrayOrValue,
       end: ArrayOrValue
     ): TransitionStates => {
-      return transitionConfigs.reduce(
+      return transitions.reduce(
         (styles, config, index) => {
           const startVal = getPrimitiveValue(start, index);
           const endVal = getPrimitiveValue(end, index);

--- a/src/factory/index.js
+++ b/src/factory/index.js
@@ -34,8 +34,8 @@ const getStyleString = (
     ? `${currentStyle} ${style}`
     : style;
 
-const transitionFactory = () => {
-  const transitions: Array<TransitionConfig> = [...arguments];
+const transitionFactory = (...args: Array<any>) => {
+  const transitions: Array<TransitionConfig> = [...args];
 
   return class extends React.Component<TransitionProps> {
     static transitions = transitions;
@@ -58,12 +58,12 @@ const transitionFactory = () => {
       easing: string
     ): string => {
       return transitions
-        .map((config, index) => {
+        .map((transition, index) => {
           const timeoutVal = getPrimitiveValue(timeout, index);
           const delayVal = getPrimitiveValue(delay, index);
           const easingVal = getPrimitiveValue(easing, index);
           return `${
-            config.transition
+            transition.transition
           } ${timeoutVal}ms ${easingVal} ${delayVal}ms`;
         })
         .join(',');
@@ -77,14 +77,14 @@ const transitionFactory = () => {
     ): Object => {
       return {
         transition: this.getTransitionProperty(timeout, delay, easing),
-        ...transitions.reduce((style, config, index) => {
+        ...transitions.reduce((style, transition, index) => {
           const startVal = getPrimitiveValue(start, index);
-          const transitionName = camelCase(config.transition);
+          const transitionName = camelCase(transition.transition);
 
           style[transitionName] = getStyleString(
             transitionName,
             style[transitionName],
-            config.getStartStyle(startVal)
+            transition.getStartStyle(startVal)
           );
           return style;
         }, {}),
@@ -96,25 +96,25 @@ const transitionFactory = () => {
       end: ArrayOrValue
     ): TransitionStates => {
       return transitions.reduce(
-        (styles, config, index) => {
+        (styles, transition, index) => {
           const startVal = getPrimitiveValue(start, index);
           const endVal = getPrimitiveValue(end, index);
-          const transitionName = camelCase(config.transition);
+          const transitionName = camelCase(transition.transition);
 
           styles.entering[transitionName] = getStyleString(
             transitionName,
             styles.entering[transitionName],
-            config.getStartStyle(startVal)
+            transition.getStartStyle(startVal)
           );
           styles.entered[transitionName] = getStyleString(
             transitionName,
             styles.entered[transitionName],
-            config.getEndStyle(endVal)
+            transition.getEndStyle(endVal)
           );
           styles.exiting[transitionName] = getStyleString(
             transitionName,
             styles.exiting[transitionName],
-            config.getStartStyle(startVal)
+            transition.getStartStyle(startVal)
           );
           styles.exited[transitionName] = styles.entering[transitionName];
           return styles;
@@ -161,7 +161,7 @@ const transitionFactory = () => {
           appear
           mountOnEnter
           unmountOnExit
-          timeout={this.getGlobalTimeout(timeout)}
+          timeout={this.getGlobalTimeout(timeout, delay)}
           {...rest}
         >
           {(state, childProps) => {

--- a/src/types/index.js
+++ b/src/types/index.js
@@ -20,8 +20,8 @@ export type TransitionConfig = {
 
 export type TransitionProps = {
   children: Function | Node,
+  timeout: Array<number | { enter?: number, exit?: number }> | number,
+  easing: ArrayOrString,
   start?: ArrayOrValue,
   end?: ArrayOrValue,
-  timeout: ArrayOrNumber,
-  easing: ArrayOrString,
 };

--- a/src/types/index.js
+++ b/src/types/index.js
@@ -21,6 +21,7 @@ export type TransitionConfig = {
 export type TransitionProps = {
   children: Function | Node,
   timeout: Array<number | { enter?: number, exit?: number }> | number,
+  delay: Array<number | { enter?: number, exit?: number }> | number,
   easing: ArrayOrString,
   start?: ArrayOrValue,
   end?: ArrayOrValue,

--- a/src/types/index.js
+++ b/src/types/index.js
@@ -20,7 +20,6 @@ export type TransitionConfig = {
 
 export type TransitionProps = {
   children: Function | Node,
-  staticStyles?: Object,
   start?: ArrayOrValue,
   end?: ArrayOrValue,
   timeout: ArrayOrNumber,

--- a/stories/index.js
+++ b/stories/index.js
@@ -5,43 +5,39 @@ import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import { linkTo } from '@storybook/addon-links';
 
-import FadeTransition from '../src/components/FadeTransition';
-import FlipTransition from '../src/components/FlipTransition';
-import ExpandTransition from '../src/components/ExpandTransition';
-import ScaleTransition from '../src/components/ScaleTransition';
-import SlideTransition from '../src/components/SlideTransition';
-import RotateTransition from '../src/components/RotateTransition';
-
 import TransitionGroupDecorator from './decorators/TransitionGroupDecorator';
 import KatPersona from './components/KatPersona';
 import WarningMessage from './components/WarningMessage';
 
 import './index.css';
 import transitionFactory from '../src/factory';
-import { opacity, translate, rotate, scale } from '../src/presets/index';
+import {
+  opacity,
+  translate,
+  rotate,
+  rotate3d,
+  scale,
+} from '../src/presets/index';
 
-const BatmanWipeTransition = transitionFactory([opacity, rotate, scale.all]);
+const FadeTransition = transitionFactory(opacity);
+const SlideTransition = transitionFactory(translate.top);
+const ExpandTransition = transitionFactory(scale.vertical);
+const FlipTransition = transitionFactory(rotate3d.top);
+const RotateTransition = transitionFactory(rotate);
+const ScaleTransition = transitionFactory(scale.all);
 
-const SwipeInTransition = transitionFactory(
-  [
-    {
-      transition: 'max-width',
-      getStartStyle: () => 0,
-      getEndStyle: () => 400,
-    },
-  ],
-  {
-    overflow: 'hidden',
-  }
-);
+const BatmanWipeTransition = transitionFactory(opacity, rotate, scale.all);
+
+const SwipeInTransition = transitionFactory({
+  transition: 'max-width',
+  getStartStyle: () => 0,
+  getEndStyle: () => 400,
+});
 
 storiesOf('Standard Transitions', module)
   .addDecorator(TransitionGroupDecorator)
   .add('Fade', () => (
-    <FadeTransition
-      onEnter={(...args) => console.log(args)}
-      transitionId="fade-transition"
-    >
+    <FadeTransition onEnter={(...args) => console.log(args)} delay={1000}>
       <KatPersona />
     </FadeTransition>
   ))


### PR DESCRIPTION
# v2.0.0.alpha.1


### Breaking Changes
- Kill `staticStyles` and `defaultProps` in function signature
  - `defaultProps` can be easily attached to generated `Transition` component from the factory
  - `staticStyles` can be attached to the `child` of the `Transition` component.

### Additions to API
- Add a `delay` property for easy `transition-delay` generation for delaying the start of certain transitions
- Add ability to set different `start` & `end` timeout values for asymmetric transitions

### Presets
- Add more presets for common use case transitions

### Tests
- Add test file for `transitionFactory`