### PR TITLE
feat(client): introduce new way of doing static styles through style prop

### DIFF
--- a/src/factory/index.js
+++ b/src/factory/index.js
@@ -135,11 +135,13 @@ const transitionFactory = (...args: Array<any>) => {
         delay: number,
         easing: string,
         start: ArrayOrValue,
-        end: ArrayOrValue
+        end: ArrayOrValue,
+        staticStyle: Object,
       ): Object => {
         return {
           ...this.getDefaultStyle(timeout, delay, easing, start),
           ...this.getTransitionStates(start, end)[state],
+          ...(staticStyle || {}),
         };
       }
     );
@@ -152,6 +154,7 @@ const transitionFactory = (...args: Array<any>) => {
         easing,
         start,
         end,
+        style: staticStyle,
         ...rest
       } = this.props;
 
@@ -171,7 +174,8 @@ const transitionFactory = (...args: Array<any>) => {
               delay,
               easing,
               start,
-              end
+              end,
+              staticStyle,
             );
 
             if (typeof children === 'function') {

--- a/src/types/index.js
+++ b/src/types/index.js
@@ -25,4 +25,5 @@ export type TransitionProps = {
   easing: ArrayOrString,
   start?: ArrayOrValue,
   end?: ArrayOrValue,
+  style?: Object,
 };


### PR DESCRIPTION
## Static Styles
Sometimes you want styles to persist across every transition state. The new way of doing this is to use the `Transition` `style` property, which will pass it down to the `child` component.

If attached to the `defaultProps` as shown below, this lends itself to more reusable transitions as it is agnostic of the `child` and the `child` does not need to add extra inline-styles for the sake of an animation (though it is still available). Currently opting for this method as it follows existing React patterns and is easy to override later via props if needed (though not always recommended).

```
const RevealTransition = transitionFactory({
   ...
});

// spread so we preserve the original defaultProps
FadeTransition.defaultProps = {
   ...FadeTransition.defaultProps,
   style: {
      overflow: 'hidden',
   },
};
```

cc @Joelkang