### PR TITLE
Convert string args to objects

### DIFF
--- a/packages/core/src/factory/index.js
+++ b/packages/core/src/factory/index.js
@@ -39,7 +39,16 @@ const getStyleString = (
     : style;
 
 const transitionFactory = (...args: Array<any>) => {
-  const transitions: Array<TransitionConfig> = [...args];
+  // If transition argument is a string, convert it into an object with default
+  // props
+  const transitions: Array<TransitionConfig> = args.map(transition => (
+    typeof transition === 'string'
+      ? {
+        transition,
+        getStartStyle: identity,
+        getEndStyle: identity,
+      } : transition
+  ));
 
   return class extends React.Component<TransitionProps> {
     static transitions = transitions;


### PR DESCRIPTION
Enables the api of passing in just the transition names, like:
`transitionFactory('width', 'height')`