### PR TITLE
fix(appear): do not transition on mount, unless appear is true

### DIFF
--- a/packages/core/src/types/index.js
+++ b/packages/core/src/types/index.js
@@ -23,6 +23,7 @@ export type TransitionProps = {
   timeout: Array<number | { enter?: number, exit?: number }> | number,
   delay: Array<number | { enter?: number, exit?: number }> | number,
   easing: ArrayOrString,
+  appear: boolean,
   start?: ArrayOrValue,
   end?: ArrayOrValue,
   style?: Object,


### PR DESCRIPTION
Currently the component will animate on first render, regardless of if `appear` is true or not.

This extra check makes sure the `transition` CSS property isn't set unless `appear` is true, or if the component has already `mounted`.

This also gets rid of the memoize layer, cos eh who needs it rn anyway